### PR TITLE
Added the remaining resources for the Coreborn army

### DIFF
--- a/assets/data/armies/TheCoreborn/tier-1/golemancer_hull.tres
+++ b/assets/data/armies/TheCoreborn/tier-1/golemancer_hull.tres
@@ -1,0 +1,29 @@
+[gd_resource type="Resource" script_class="UnitType" load_steps=2 format=3 uid="uid://bi1emdxgtp06q"]
+
+[ext_resource type="Script" uid="uid://cogrj3h8s8nxx" path="res://scripts/unit_type.gd" id="1_igik6"]
+
+[resource]
+script = ExtResource("1_igik6")
+unit_name = "Golemancer Hull"
+unit_role = "Heavy Armor"
+unit_tier = 1
+can_upgrade = true
+upgrade_cost = 5
+unit_description = "Massive exo-shell driven by arcane tech. Slow, powerful, and resilient."
+unit_cost_type = "standard"
+unit_cost = 3
+stats_block = {
+"armor": 2,
+"attack": 3,
+"health": 5,
+"range": 1,
+"speed": 2
+}
+terrain_type_matrix = {
+"field": 1,
+"forest": 2,
+"mountain": 10,
+"water": -1
+}
+special_abilities = Array[String](["Splash damage in adjacent hexes"])
+metadata/_custom_type_script = "uid://cogrj3h8s8nxx"

--- a/assets/data/armies/TheCoreborn/tier-1/shard_walker.tres
+++ b/assets/data/armies/TheCoreborn/tier-1/shard_walker.tres
@@ -1,0 +1,29 @@
+[gd_resource type="Resource" script_class="UnitType" load_steps=2 format=3 uid="uid://dslsv0yfxylc1"]
+
+[ext_resource type="Script" uid="uid://cogrj3h8s8nxx" path="res://scripts/unit_type.gd" id="1_6iqno"]
+
+[resource]
+script = ExtResource("1_6iqno")
+unit_name = "Shard Walker"
+unit_role = "Core Infantry"
+unit_tier = 1
+can_upgrade = true
+upgrade_cost = 3
+unit_description = "Light troops augmented with crystal tech for standard mobility."
+unit_cost_type = "standard"
+unit_cost = 1
+stats_block = {
+"armor": 0,
+"attack": 1,
+"health": 3,
+"range": 1,
+"speed": 4
+}
+terrain_type_matrix = {
+"field": 1,
+"forest": 2,
+"mountain": 5,
+"water": -1
+}
+special_abilities = Array[String]([])
+metadata/_custom_type_script = "uid://cogrj3h8s8nxx"

--- a/assets/data/armies/TheCoreborn/tier-1/sky_render.tres
+++ b/assets/data/armies/TheCoreborn/tier-1/sky_render.tres
@@ -1,0 +1,29 @@
+[gd_resource type="Resource" script_class="UnitType" load_steps=2 format=3 uid="uid://c84ojdvoj3brv"]
+
+[ext_resource type="Script" uid="uid://cogrj3h8s8nxx" path="res://scripts/unit_type.gd" id="1_2hema"]
+
+[resource]
+script = ExtResource("1_2hema")
+unit_name = "Sky Render"
+unit_role = "Hover Craft"
+unit_tier = 1
+can_upgrade = true
+upgrade_cost = 15
+unit_description = "Hovering drone-rider capable of crossing all terrain types."
+unit_cost_type = "standard"
+unit_cost = 12
+stats_block = {
+"armor": 1,
+"attack": 2,
+"health": 2,
+"range": 2,
+"speed": 8
+}
+terrain_type_matrix = {
+"field": 1,
+"forest": 1,
+"mountain": 1,
+"water": 1
+}
+special_abilities = Array[String](["Ignores terrain penalties", "may move again after combat once per game"])
+metadata/_custom_type_script = "uid://cogrj3h8s8nxx"

--- a/assets/data/armies/TheCoreborn/tier-1/tide_born.tres
+++ b/assets/data/armies/TheCoreborn/tier-1/tide_born.tres
@@ -1,0 +1,29 @@
+[gd_resource type="Resource" script_class="UnitType" load_steps=2 format=3 uid="uid://88nmx0kl6ilv"]
+
+[ext_resource type="Script" uid="uid://cogrj3h8s8nxx" path="res://scripts/unit_type.gd" id="1_tvlwq"]
+
+[resource]
+script = ExtResource("1_tvlwq")
+unit_name = "Tide Born"
+unit_role = "Amphibious"
+unit_tier = 1
+can_upgrade = true
+upgrade_cost = 5
+unit_description = "Bio-engineered aquatic troopers with amphibious mobility."
+unit_cost_type = "standard"
+unit_cost = 2
+stats_block = {
+"armor": 0,
+"attack": 2,
+"health": 2,
+"range": 1,
+"speed": 3
+}
+terrain_type_matrix = {
+"field": 1,
+"forest": 2,
+"mountain": 5,
+"water": 1
+}
+special_abilities = Array[String](["Can move on water"])
+metadata/_custom_type_script = "uid://cogrj3h8s8nxx"

--- a/scripts/unit_type.gd
+++ b/scripts/unit_type.gd
@@ -40,7 +40,7 @@ class_name UnitType
 	"field": 1,
 	"forest": 2,
 	"mountain": 5,
-	"water": 0
+	"water": -1
 }
 
 ## Any Special Abilities


### PR DESCRIPTION
Added resources for the following units:
- Golemancer Hull
- Shard Walker
- Sky Render
- Tide Born

Updated unit_type.gd so that default water movement is -1 indicating that the unit is not able to traverse water by default.

I foresee a conflict in the future where movement cost designated by terrain type will conflict with unit Terrain Type Matrix. I should clarify in the rules that the movement costs for the terrain are defaults, and different units can have different movement costs associated with each terrain type.